### PR TITLE
Allow to set a delay for reordering

### DIFF
--- a/projects/ngx-easy-table/src/lib/components/base/base.component.html
+++ b/projects/ngx-easy-table/src/lib/components/base/base.component.html
@@ -440,7 +440,10 @@
             let rowIndex = index
           "
         >
-          <tr class="ngx-draggable-row" cdkDrag cdkDragLockAxis="y">
+          <tr class="ngx-draggable-row"
+              cdkDrag
+              [cdkDragStartDelay]="config.reorderDelay || 0"
+              cdkDragLockAxis="y">
             <td *ngIf="config.checkboxes">
               <label class="ngx-form-checkbox">
                 <input

--- a/projects/ngx-easy-table/src/lib/components/thead/thead.component.html
+++ b/projects/ngx-easy-table/src/lib/components/thead/thead.component.html
@@ -114,6 +114,7 @@
       class="ngx-table__header-cell ngx-table__header-cell--draggable"
       cdkDragLockAxis="x"
       cdkDrag
+      [cdkDragStartDelay]="config.reorderDelay || 0"
       [class.pinned-left]="column.pinned"
       [ngClass]="column.cssClass && column.cssClass.includeHeader ? column.cssClass.name : ''"
       [style.left]="styleService.pinnedWidth(column.pinned, colIndex)"

--- a/projects/ngx-easy-table/src/lib/model/config.ts
+++ b/projects/ngx-easy-table/src/lib/model/config.ts
@@ -33,6 +33,7 @@ export interface Config {
   threeWaySort?: boolean;
   columnReorder?: boolean;
   rowReorder?: boolean;
+  reorderDelay?: number;
   infiniteScroll?: boolean;
   infiniteScrollThrottleTime?: number;
   tableLayout: {


### PR DESCRIPTION
Hi @ssuperczynski , the PR adds the possibility to configure a delay before Angular CDK dragging begins. Having reordering enabled without a delay, scrolling on an iPad is not possible since the dragging immediately takes place.